### PR TITLE
feat: add refresh token

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>br.com.atilara</groupId>
 	<artifactId>authenticationjwt</artifactId>
-	<version>1.0.5</version>
+	<version>1.1.0</version>
 	<name>security</name>
 	<description>Learning JWT auth in Spring Boot</description>
 	<properties>

--- a/src/main/java/br/com/atilara/authenticationjwt/auth/AuthenticationController.java
+++ b/src/main/java/br/com/atilara/authenticationjwt/auth/AuthenticationController.java
@@ -1,11 +1,15 @@
 package br.com.atilara.authenticationjwt.auth;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
 
 @RestController
 @RequestMapping("/api/v1/auth")
@@ -23,6 +27,14 @@ public class AuthenticationController {
     public ResponseEntity<AuthenticationResponse> login(@RequestBody AuthenticationRequest request) {
         return ResponseEntity.ok(authenticationService.login(request));
 
+    }
+
+    @PostMapping("/refresh-token")
+    public void refreshToken(
+            HttpServletRequest request,
+            HttpServletResponse response
+    ) throws IOException {
+        authenticationService.refreshToken(request, response);
     }
 
 }

--- a/src/main/java/br/com/atilara/authenticationjwt/auth/AuthenticationResponse.java
+++ b/src/main/java/br/com/atilara/authenticationjwt/auth/AuthenticationResponse.java
@@ -11,6 +11,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class AuthenticationResponse {
 
-    private String jwt;
+    private String accessToken;
+
+    private String refreshToken;
 
 }

--- a/src/main/java/br/com/atilara/authenticationjwt/config/JwtService.java
+++ b/src/main/java/br/com/atilara/authenticationjwt/config/JwtService.java
@@ -21,18 +21,32 @@ public class JwtService {
     @Value("${application.security.jwt.secret-key}")
     private String secretKey;
 
-    public String generateToken(Map<String, Object> extraClaims, UserDetails userDetails) {
+    @Value("${application.security.jwt.expiration-time}")
+    private long accessTokenExpiration;
+
+    @Value("${application.security.jwt.refresh-token.expiration-time}")
+    private long refreshTokenExpiration;
+
+    public String generateAccessToken(Map<String, Object> extraClaims, UserDetails userDetails) {
+        return buildToken(extraClaims, userDetails, accessTokenExpiration);
+    }
+
+    public String generateRefreshToken(UserDetails userDetails) {
+        return buildToken(new HashMap<>(), userDetails, refreshTokenExpiration);
+    }
+
+    public String buildToken(Map<String, Object> extraClaims, UserDetails userDetails, long expirationTime) {
         return Jwts.builder()
                 .setClaims(extraClaims)
                 .setSubject(userDetails.getUsername())
                 .setIssuedAt(new Date(System.currentTimeMillis()))
-                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60)) // 1 hour
+                .setExpiration(new Date(System.currentTimeMillis() + expirationTime))
                 .signWith(getSigningKey(), SignatureAlgorithm.HS256)
                 .compact();
     }
 
-    public String generateToken(UserDetails userDetails) {
-        return generateToken(new HashMap<>(), userDetails);
+    public String generateAccessToken(UserDetails userDetails) {
+        return generateAccessToken(new HashMap<>(), userDetails);
     }
 
     private Date extractExpiration(String jwt) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,3 +19,6 @@ application:
   security:
     jwt:
       secret-key: ${JWT_SECRET_KEY}
+      expiration-time: 86400000 # 1 day
+      refresh-token:
+        expiration-time: 604800000 # 7 days


### PR DESCRIPTION
- Add refresh token
  - Access token is valid for one day, can be changed
  - Refresh token is valid for seven days, can be changed
  - When the access token is expired, the refresh-token route can be used to get a new access token
  - When the refresh token is expired, the user has to log in again

Closes #10 