### PR TITLE
ci: reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM openjdk:17-jdk
 
 WORKDIR /app
 
-COPY target/authenticationjwt-* /app/authenticationjwt.jar
+COPY target/authenticationjwt-*.jar /app/authenticationjwt.jar
 
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk
+FROM bellsoft/liberica-openjdk-alpine:17
 
 WORKDIR /app
 


### PR DESCRIPTION
## Added
- Use `bellsoft/liberica-openjdk-alpine:17` as base image to reduce image size, Closes #1 

## Fixed
- `COPY` command wasn't getting the right `.jar` and returning the error `no main manifest attribute, in authenticationjwt.jar`
